### PR TITLE
docs: add mac/linux build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Achieve
+
 An organisational tool that organises tasks according to projects or goals
+
+## Building
+
+On Unix-like systems, you can build using `dotnet`:
+
+```shell
+dotnet tool install --global Paket
+packet install
+dotnet build
+```
+
+[LICENSE (GPL-3.0)](./LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ On Unix-like systems, you can build using `dotnet`:
 
 ```shell
 dotnet tool install --global Paket
-packet install
+paket install
 dotnet build
 ```
 


### PR DESCRIPTION
I got this to work using just regular global dotnet. Closes #3.